### PR TITLE
implemented _fixed_stepsize_integrators: Euler, Midpoint, RK4

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install
         run: |
@@ -52,7 +52,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Tenavi
+Copyright (c) 2022-2024 Tenavi Nakamura-Zimmerer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 *This software is being developed independently of NASA. It is not endorsed or supported by NASA or the US government.*
 
 ##### Authors
-* Tenavi Nakamura-Zimmerer (tenavi.nakamura-zimmerer@nasa.gov)
+* Tenavi Nakamura-Zimmerer (tenavi.nz@gmail.com, tenavi.nakamura-zimmerer@nasa.gov)
 * Jiequn Han (jhan@flatironinstitute.org)
 * Qi Gong (qgong@ucsc.edu)
 * Wei Kang (wkang@nps.edu)

--- a/examples/burgers/problem_definition.py
+++ b/examples/burgers/problem_definition.py
@@ -367,7 +367,7 @@ def plot_closed_loop(sims, open_loop_sols, t_max=None, x_min=None, x_max=None,
     ----------
     sims : length n_sims list of dicts
         Closed loop simulations output by
-        `optimalcontrol.simulate.monte_carlo_fixed_time` or
+        `optimalcontrol.simulate.monte_carlo` or
         `optimalcontrol.simulate.monte_carlo_to_converge`. Each element of
         `sims` should be a dict with keys
 

--- a/examples/common_utilities/plotting.py
+++ b/examples/common_utilities/plotting.py
@@ -108,7 +108,7 @@ def plot_closed_loop_3d(sims, open_loop_sols, z='u',
     ----------
     sims : length n_sims list of dicts
         Closed loop simulations output by
-        `optimalcontrol.simulate.monte_carlo_fixed_time` or
+        `optimalcontrol.simulate.monte_carlo` or
         `optimalcontrol.simulate.monte_carlo_to_converge`. Each element of
         `sims` should be a dict with keys
 
@@ -196,7 +196,7 @@ def plot_closed_loop(sims, t_max=None, x_index=None, u_index=None,
     ----------
     sims : length n_sims list of dicts
         Closed loop simulations output by
-        `optimalcontrol.simulate.monte_carlo_fixed_time` or
+        `optimalcontrol.simulate.monte_carlo` or
         `optimalcontrol.simulate.monte_carlo_to_converge`. Each element of
         `sims` should be a dict with keys
 

--- a/optimalcontrol/__init__.py
+++ b/optimalcontrol/__init__.py
@@ -2,4 +2,4 @@
 .. include:: ../README.md
 """
 
-__version__ = '0.9.1'
+__version__ = '0.9.2'

--- a/optimalcontrol/__init__.py
+++ b/optimalcontrol/__init__.py
@@ -2,4 +2,4 @@
 .. include:: ../README.md
 """
 
-__version__ = '0.9.2'
+__version__ = '0.10.0'

--- a/optimalcontrol/controls.py
+++ b/optimalcontrol/controls.py
@@ -83,11 +83,9 @@ class Controller:
             default 'uniform_average'.
 
                 * 'raw_values' : Returns a full set of scores for each control.
-
                 * 'uniform_average' :
                     Scores of all control dimensions are averaged with uniform
                     weight.
-
                 * 'variance_weighted' :
                     Scores of all control dimensions are averaged, weighted by
                     the variances of each individual control.

--- a/optimalcontrol/open_loop/direct/_optimize.py
+++ b/optimalcontrol/open_loop/direct/_optimize.py
@@ -196,8 +196,7 @@ def _minimize_slsqp(fun, x0, args=(), jac=None, bounds=None, constraints=(),
     if not disp:
         iprint = 0
 
-    # Transform x0 into an array.
-    x = np.asfarray(x0).flatten()
+    x = np.asarray(x0).flatten()
 
     # SLSQP is sent 'old-style' bounds, 'new-style' bounds are required by
     # ScalarFunction

--- a/optimalcontrol/simulate/__init__.py
+++ b/optimalcontrol/simulate/__init__.py
@@ -21,5 +21,5 @@ performance and stability testing of feedback control laws.
     multiple initial conditions.
 """
 
-from .simulate import (integrate_fixed_time, integrate_to_converge,
-                       monte_carlo_fixed_time, monte_carlo_to_converge)
+from .simulate import (integrate, integrate_to_converge,
+                       monte_carlo, monte_carlo_to_converge)

--- a/optimalcontrol/simulate/_fixed_stepsize_integrators.py
+++ b/optimalcontrol/simulate/_fixed_stepsize_integrators.py
@@ -1,0 +1,185 @@
+import numpy as np
+
+from scipy.integrate import OdeSolver
+from scipy.integrate._ivp.rk import rk_step, RkDenseOutput
+
+
+class FixedStepSolver(OdeSolver):
+    """Base class for explicit fixed stepsize Runge-Kutta methods.
+
+    Based on `scipy.integrate._ivp.rk.RungeKutta`."""
+    C: np.ndarray = NotImplemented
+    A: np.ndarray = NotImplemented
+    B: np.ndarray = NotImplemented
+    P: np.ndarray = NotImplemented
+    _min_dt = 1e-10
+
+    def __init__(self, fun, t0, y0, t_bound, dt=None, vectorized=False,
+                 **extraneous):
+        super().__init__(fun, t0, y0, t_bound, vectorized, support_complex=True)
+
+        self.y_old = None
+        self.f = self.fun(self.t, self.y)
+        if dt is None or dt <= np.finfo(float).eps:
+            raise ValueError("dt must be positive.")
+        self.dt = np.maximum(self._min_dt, self._validate_stepsize(dt))
+
+        self.K = np.empty((self.n_stages + 1, self.n), dtype=self.y.dtype)
+
+    @property
+    def n_stages(self):
+        return self.C.shape[0]
+
+    def _validate_stepsize(self, dt):
+        max_dt = np.abs(self.t_bound - self.t)
+
+        # Stepping by dt accumulates small errors. If stepping by dt would get
+        # almost to the end of the time interval, use a slightly larger timestep
+        # which gets there exactly.
+        if dt >= self._min_dt >= max_dt - dt:
+            return max_dt
+
+        return np.minimum(dt, max_dt)
+
+    def _step_impl(self):
+        self.dt = self._validate_stepsize(self.dt)
+
+        h = self.dt * self.direction
+
+        y_new, f_new = rk_step(self.fun, self.t, self.y, self.f, h,
+                               self.A, self.B, self.C, self.K)
+
+        self.y_old = self.y
+        self.t = self.t + h
+        self.y = y_new
+        self.f = f_new
+
+        return True, None
+
+    def _dense_output_impl(self):
+        Q = self.K.T.dot(self.P)
+        return RkDenseOutput(self.t_old, self.t, self.y_old, Q)
+
+
+class Euler(FixedStepSolver):
+    """Explicit Euler method with fixed timestep.
+
+    This is a first order method. Linear interpolation is used for dense output.
+
+    Parameters
+    ----------
+    fun : callable
+        Right-hand side of the system. The calling signature is `fun(t, y)`.
+        Here `t` is a scalar, and there are two options for the ndarray `y`:
+        It can either have shape (n,); then `fun` must return array_like with
+        shape (n,). Alternatively it can have shape (n, k); then `fun`
+        must return an array_like with shape (n, k), i.e., each column
+        corresponds to a single column in `y`. The choice between the two
+        options is determined by `vectorized` argument (see below).
+    t0 : float
+        Initial time.
+    y0 : array_like, shape (n,)
+        Initial state.
+    t_bound : float
+        Boundary time - the integration won't continue beyond it. It also
+        determines the direction of the integration.
+    dt : float
+        Absolute time step size. Must be positive.
+    vectorized : bool, optional
+        Whether `fun` is implemented in a vectorized fashion. Default is False.
+    """
+    C = np.array([0.])
+    A = np.array([[0.]])
+    B = np.array([1.])
+    P = np.array([[1.],
+                  [0.]])
+
+
+class Midpoint(FixedStepSolver):
+    """Explicit midpoint method with fixed timestep.
+
+    This is a second order method. A quadratic Hermite polynomial is used for
+    dense output.
+
+    Parameters
+    ----------
+    fun : callable
+        Right-hand side of the system. The calling signature is `fun(t, y)`.
+        Here `t` is a scalar, and there are two options for the ndarray `y`:
+        It can either have shape (n,); then `fun` must return array_like with
+        shape (n,). Alternatively it can have shape (n, k); then `fun`
+        must return an array_like with shape (n, k), i.e., each column
+        corresponds to a single column in `y`. The choice between the two
+        options is determined by `vectorized` argument (see below).
+    t0 : float
+        Initial time.
+    y0 : array_like, shape (n,)
+        Initial state.
+    t_bound : float
+        Boundary time - the integration won't continue beyond it. It also
+        determines the direction of the integration.
+    dt : float
+        Absolute time step size. Must be positive.
+    vectorized : bool, optional
+        Whether `fun` is implemented in a vectorized fashion. Default is False.
+    """
+    C = np.array([0., 1/2])
+    A = np.array([[0., 0.],
+                  [1/2, 0.]])
+    B = np.array([0., 1.])
+    P = np.array([[1., -1.],
+                  [0., 1.],
+                  [0., 0.]])
+
+
+class RK4(FixedStepSolver):
+    """Explicit fourth order Runge-Kutta method with fixed timestep.
+
+    This is the classic fourth order Runge-Kutta method. A cubic Hermite
+    polynomial is used for dense output.
+
+    Parameters
+    ----------
+    fun : callable
+        Right-hand side of the system. The calling signature is `fun(t, y)`.
+        Here `t` is a scalar, and there are two options for the ndarray `y`:
+        It can either have shape (n,); then `fun` must return array_like with
+        shape (n,). Alternatively it can have shape (n, k); then `fun`
+        must return an array_like with shape (n, k), i.e., each column
+        corresponds to a single column in `y`. The choice between the two
+        options is determined by `vectorized` argument (see below).
+    t0 : float
+        Initial time.
+    y0 : array_like, shape (n,)
+        Initial state.
+    t_bound : float
+        Boundary time - the integration won't continue beyond it. It also
+        determines the direction of the integration.
+    dt : float
+        Absolute time step size. Must be positive.
+    vectorized : bool, optional
+        Whether `fun` is implemented in a vectorized fashion. Default is False.
+    """
+    C = np.array([0., 1/2, 1/2, 1.])
+    A = np.array([[0., 0., 0., 0.],
+                  [1/2, 0., 0., 0.],
+                  [0., 1/2, 0., 0.],
+                  [0., 0., 1., 0.]])
+    B = np.array([1/6, 1/3, 1/3, 1/6])
+
+    def _dense_output_impl(self):
+        y_slope = (self.y - self.y_old) / (self.t - self.t_old)
+
+        Q = np.empty((self.n, 3))
+
+        # Constraint on linear term that dy/dt(t0) = f(t0, y0)
+        Q[:, 0] = self.K[0]
+        # Constraints on quadratic and cubic terms such that
+        #   y(t0 + h) = y1 and dy/dt(t0 + h) = f(t0 + h, y1)
+        Q[:, 1] = - (2. * self.K[0] + self.K[-1] - 3. * y_slope)
+        Q[:, 2] = self.K[0] + self.K[-1] - 2. * y_slope
+
+        return RkDenseOutput(self.t_old, self.t, self.y_old, Q)
+
+
+METHODS = {'Euler': Euler, 'Midpoint': Midpoint, 'RK4': RK4}

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ if __name__ == '__main__':
         long_description=long_description,
         long_description_content_type='text/markdown',
         author='Tenavi Nakamura-Zimmerer',
-        author_email='tenavi.nakamura-zimmerer@nasa.gov',
         packages=['optimalcontrol'],
         python_requires='>=3.8',
         install_requires=requirements)

--- a/tests/test_open_loop/test_indirect.py
+++ b/tests/test_open_loop/test_indirect.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from optimalcontrol.open_loop import indirect
-from optimalcontrol.simulate import integrate_fixed_time
+from optimalcontrol.simulate import integrate
 from optimalcontrol.problem import LinearQuadraticProblem
 from optimalcontrol.controls import LinearQuadraticRegulator
 
@@ -36,7 +36,7 @@ def get_lqr_sol(ocp, lqr, x0, t1, t_eval=None):
     else:
         t_span = [t_eval[0], t_eval[-1]]
 
-    t, x, _ = integrate_fixed_time(ocp, lqr, x0, t_span, t_eval=t_eval)
+    t, x, _ = integrate(ocp, lqr, x0, t_span, t_eval=t_eval)
     p = 2. * lqr.P @ (x - lqr.xf)
     u = lqr(x)
 

--- a/tests/test_simulate/test_ivp.py
+++ b/tests/test_simulate/test_ivp.py
@@ -1,0 +1,200 @@
+import warnings
+
+import numpy as np
+import pytest
+from scipy.interpolate import make_interp_spline
+from scipy.integrate import solve_ivp as scipy_solve_ivp
+
+from optimalcontrol.simulate._ivp import solve_ivp
+from optimalcontrol.simulate import _fixed_stepsize_integrators
+from optimalcontrol.utilities import approx_derivative
+
+
+rng = np.random.default_rng(123)
+
+
+@pytest.mark.parametrize('n_states', [1, 2])
+@pytest.mark.parametrize('dt', [1e-01, 1e-02])
+def test_Euler(n_states, dt):
+    t0 = rng.normal()
+
+    x0 = rng.normal(size=(n_states,))
+
+    def f(t, x):
+        return np.cos(t) * x
+
+    for tf in (t0 + rng.uniform(0., 1.), t0 + dt / 2.):
+        solver = _fixed_stepsize_integrators.Euler(f, t0, x0, tf, dt=dt)
+        solver.step()
+
+        # Compare solver output with expected
+        h = np.minimum(tf - t0, dt)
+        f0 = f(t0, x0)
+        xf_expect = x0 + h * f0
+
+        assert solver.t == t0 + h
+        np.testing.assert_allclose(solver.y, xf_expect)
+
+        # Dense output should satisfy the constraints
+        #   x(t0) = x0
+        #   x(t0 + h) = xf
+        #   dx/dt(t0) = f(t0, x0)
+        ode_sol = solver.dense_output()
+
+        np.testing.assert_allclose(ode_sol(t0), x0)
+        np.testing.assert_allclose(ode_sol(solver.t), solver.y,
+                                   atol=1e-12, rtol=1e-06)
+        dxdt = approx_derivative(ode_sol, t0, method='cs').flatten()
+        np.testing.assert_allclose(dxdt, f0, atol=1e-12, rtol=1e-06)
+        
+        
+@pytest.mark.parametrize('n_states', [1, 2])
+@pytest.mark.parametrize('dt', [1e-01, 1e-02])
+def test_Midpoint(n_states, dt):
+    t0 = rng.normal()
+
+    x0 = rng.normal(size=(n_states,))
+
+    def f(t, x):
+        return np.cos(t) * x
+
+    for tf in (t0 + rng.uniform(0., 1.), t0 + dt / 2.):
+        solver = _fixed_stepsize_integrators.Midpoint(f, t0, x0, tf, dt=dt)
+        solver.step()
+
+        # Compare solver output with expected
+        h = np.minimum(tf - t0, dt)
+        t1 = t0 + h / 2.
+        f0 = f(t0, x0)
+        k1 = x0 + h / 2. * f0
+        f1 = f(t1, k1)
+        xf_expect = x0 + h * f1
+
+        assert solver.t == t0 + h
+        np.testing.assert_allclose(solver.y, xf_expect)
+
+        # Dense output should satisfy the constraints
+        #   x(t0) = x0
+        #   x(t0 + h) = xf
+        #   dx/dt(t0) = f(t0, x0)
+        #   dx/dt(t1) = f(t1, k1)
+        ode_sol = solver.dense_output()
+
+        np.testing.assert_allclose(ode_sol(t0), x0)
+        np.testing.assert_allclose(ode_sol(solver.t), solver.y,
+                                   atol=1e-12, rtol=1e-06)
+        dxdt = approx_derivative(ode_sol, t0, method='cs').flatten()
+        np.testing.assert_allclose(dxdt, f0, atol=1e-12, rtol=1e-06)
+        dxdt = approx_derivative(ode_sol, t1, method='cs').flatten()
+        np.testing.assert_allclose(dxdt, f1, atol=1e-12, rtol=1e-06)
+
+
+@pytest.mark.parametrize('n_states', [1, 2])
+@pytest.mark.parametrize('dt', [1., 1e-01, 1e-02])
+def test_RK4(n_states, dt):
+    t0 = rng.normal()
+
+    x0 = rng.normal(size=(n_states,))
+
+    def f(t, x):
+        return np.cos(t) * x
+
+    for tf in (t0 + rng.uniform(0., 1.), t0 + dt / 2.):
+        solver = _fixed_stepsize_integrators.RK4(f, t0, x0, tf, dt=dt)
+        solver.step()
+
+        # Compare solver output with expected
+        h = np.minimum(tf - t0, dt)
+
+        k1 = f(t0, x0)
+        k2 = f(t0 + h / 2., x0 + h / 2. * k1)
+        k3 = f(t0 + h / 2., x0 + h / 2. * k2)
+        k4 = f(t0 + h, x0 + h * k3)
+        xf_expect = x0 + h / 6. * (k1 + 2. * k2 + 2. * k3 + k4)
+
+        assert solver.t == t0 + h
+        np.testing.assert_allclose(solver.y, xf_expect)
+
+        # Dense output should satisfy the constraints
+        #   x(t0) = x0
+        #   x(t0 + h) = xf
+        #   dx/dt(t0) = f(t0, x0)
+        #   dx/dt(t0 + h) = f(t0 + h, xf)
+        ode_sol = solver.dense_output()
+
+        np.testing.assert_allclose(ode_sol(t0), x0)
+        np.testing.assert_allclose(ode_sol(solver.t), solver.y,
+                                   atol=1e-12, rtol=1e-06)
+        dxdt = approx_derivative(ode_sol, t0, method='cs').flatten()
+        np.testing.assert_allclose(dxdt, k1, atol=1e-12, rtol=1e-06)
+        dxdt = approx_derivative(ode_sol, t0 + h, method='cs').flatten()
+        np.testing.assert_allclose(dxdt, f(t0 + h, xf_expect),
+                                   atol=1e-12, rtol=1e-06)
+
+
+@pytest.mark.parametrize('method', ['Euler', 'Midpoint', 'RK4'])
+@pytest.mark.parametrize('dt', [1e-01, 1e-02])
+def test_solve_ivp_fixed_stepsize(method, dt):
+    t0 = rng.normal()
+    t1 = t0 + 10.
+
+    t_expect = np.arange(t0, t1, dt)
+    t_expect = np.concatenate((t_expect, [t1]))
+
+    x0 = rng.normal(size=(1,))
+
+    def f(t, x):
+        return np.cos(t) * x
+
+    ode_sol = solve_ivp(f, [t0, t1], x0, method=method, dt=dt)
+
+    np.testing.assert_allclose(ode_sol.t, t_expect, atol=1e-12)
+
+    ref_sol = solve_ivp(f, [t0, t1], x0, method='RK45', t_eval=ode_sol.t,
+                        atol=1e-12, rtol=1e-06)
+
+    order = _fixed_stepsize_integrators.METHODS[method].C.shape[0]
+    tol = np.maximum(1e-05, 10. * dt ** order)
+    np.testing.assert_allclose(ode_sol.y, ref_sol.y, atol=tol, rtol=tol)
+
+
+@pytest.mark.parametrize('method', ['RK45', 'BDF'])
+@pytest.mark.parametrize('eps', [1e-03, 1e-02])
+def test_solve_ivp_events(method, eps):
+    t1 = 2.
+    t_eval = np.linspace(0., t1, 2001)
+
+    x0 = rng.normal(size=(1,))
+
+    c = 0.1
+
+    def f(t, x):
+        return c * x
+
+    # Solution with slightly perturbed parameters
+    ref_sol = make_interp_spline(t_eval, x0 * np.exp((c + eps) * t_eval),
+                                 k=1, axis=-1)
+
+    # Want integration to stop when square error is greater than eps ** 2
+    def integration_event(t, x):
+        return (ref_sol(t).T - x) ** 2 - eps ** 2
+
+    # The event condition starts negative, integration should stop when this
+    # becomes positive
+    integration_event.direction = 1
+    integration_event.terminal = True
+
+    kwargs = {'t_eval': t_eval, 'method': method, 'events': integration_event}
+    args = (f, [0., t1], x0)
+
+    with warnings.catch_warnings():
+        # Silence warning about 1d array to scalar conversion
+        warnings.filterwarnings('ignore', category=DeprecationWarning)
+        ref_ode_sol = scipy_solve_ivp(*args, **kwargs)
+
+    ode_sol = solve_ivp(*args, exact_event_times=True, **kwargs)
+
+    np.testing.assert_array_equal(ode_sol.t, ref_ode_sol.t)
+    np.testing.assert_array_equal(ode_sol.y, ref_ode_sol.y)
+
+    assert not np.any(integration_event(ode_sol.t, ode_sol.y) > 0.)

--- a/tests/test_simulate/test_simulate.py
+++ b/tests/test_simulate/test_simulate.py
@@ -10,7 +10,7 @@ from tests._utilities import make_LQ_params
 
 @pytest.mark.parametrize('method', ['RK45', 'BDF'])
 @pytest.mark.parametrize('u_ub', (None, 0.5))
-def test_integrate_closed_loop_lqr(method, u_ub):
+def test_integrate_lqr(method, u_ub):
     """
     Basic test of an LQR-controlled linear system integrated over a fixed time
     horizon. Since the closed-loop system should be stable, checks that the
@@ -59,7 +59,7 @@ def test_integrate_closed_loop_lqr(method, u_ub):
 @pytest.mark.parametrize('x_lb', (None, [-np.inf, -np.inf],
                                   [-0.25, -np.inf], [-0.25, -0.75]))
 @pytest.mark.parametrize('x0', ([0., 0.5], [0., -0.5]))
-def test_integrate_closed_loop_bound_events(x_ub, x_lb, x0):
+def test_integrate_bound_events(x_ub, x_lb, x0):
     n_states = 2
     n_controls = 1
 


### PR DESCRIPTION
- Implements explicit fixed step-size  Runge-Kutta methods, which are available in `simulate` with `method='Euler'`, `'Midpoint'`, or `'RK4'`.
- Renames `integrate_fixed_time` and `monte_carlo_fixed_time` to `integrate` and `monte_carlo`, respectively.

Closes #48 